### PR TITLE
spec: lock v0.4.0 (rules/rates/iCal/providers/owner-subscription)

### DIFF
--- a/docs/spec/CHANGELOG.md
+++ b/docs/spec/CHANGELOG.md
@@ -1,0 +1,8 @@
+# CHANGELOG (Spec)
+
+## 0.4.0 — 2025-09-19
+- Add: Rule/Rate エンジンの I/F（優先度と上書き順の定義）
+- Add: iCal 同期の重複排除（UID/SEQUENCE/DTSTAMP/CANCEL）
+- Add: Provider Adapter の命名/配置（Channel/Payment）
+- Add: Owner サブスクの状態遷移（active → warning → suspended）
+- Decide: 多言語は WPML 優先、Polylang は将来検証

--- a/docs/spec/VERSION
+++ b/docs/spec/VERSION
@@ -1,0 +1,3 @@
+spec: 0.4.0
+date: 2025-09-19
+notes: Initial lock for Rule/Rate engines, iCal dedupe, Provider adapters, owner subscription model.

--- a/docs/spec/architecture.md
+++ b/docs/spec/architecture.md
@@ -1,0 +1,27 @@
+# Architecture Overview
+
+## Modules
+- Sync: iCal Import/Export + Reconciliation
+- Rules: Min/Max nights, Check-in/out DOW, Buffer, Blackout
+- Rates: Season, DayOfWeek, LengthOfStay, LastMinute
+- Payments: Stripe (auth/deposit/capture/refund)
+- Portal: Owner/Manager roles, listing status (active/warning/suspended)
+- Providers: Channel/* (future), Payment/* (Stripe first)
+- API: REST (read-first), Webhooks (booking/payment)
+- i18n: WPML-first policy
+
+## Key Interfaces (PHP)
+- Contracts/Rules/RuleInterface::applies|validate|priority
+- Services/Rules/RuleEngine (Pipeline)
+- Contracts/Rates/ResolverInterface
+- Services/Rates/RateResolver
+- Providers/Channel/AbstractChannelProvider
+- Sync/IcalImporter, Sync/IcalExporter (UID/SEQUENCE/DTSTAMP/CANCEL)
+
+## Overwrite Order
+Global < PropertyType < Property
+
+## Data Hints
+- Availability bitmap (property_id, yyyymmdd, bits)
+- Booking ledger (event-sourced)
+- Owner accounts (stripe_customer_id, plan, status)

--- a/docs/spec/requirements-checklist.md
+++ b/docs/spec/requirements-checklist.md
@@ -1,0 +1,30 @@
+# Requirements Checklist (○=done / △=partial / ×=todo)
+
+## Sync & Inventory
+- [ ] iCal 2-way (UID/SEQUENCE/DTSTAMP/Cancel) …… ×
+- [ ] Buffer/Blackout/Check-in DOW rules ………… ×
+- [ ] Channel Provider Adapter skeleton ………… ×
+
+## Pricing & Rules
+- [ ] RateResolver (Season/DOW/LOS) ……………… ×
+- [ ] Taxes/Fees calculator (unit/day/person) …… ×
+- [ ] Coupons (flat/%) w/ conditions ……………… ×
+
+## Booking & Payment
+- [ ] Multi-room cart …………………………………… ×
+- [ ] Booking state machine + Ledger ……………… ×
+- [ ] Stripe (auth/deposit/capture/refund) ……… ×
+
+## Portal
+- [ ] Owner roles & capabilities …………………… ×
+- [ ] Stripe subscription for listing ……………… △
+- [ ] Official-site template link …………………… △
+
+## UI/UX
+- [ ] Availability calendar (per property) ……… △
+- [ ] Quote breakdown (tax/fees) …………………… ×
+
+## API & Ops
+- [ ] REST read-only (availability/quote) ……… ×
+- [ ] Webhook (booking/payment) …………………… ×
+- [ ] i18n policy (.po/.mo, key naming) ………… △


### PR DESCRIPTION
### 目的
仕様ロック v0.4.0 の導入（Rules/Rate 仕様、iCal 重複排除、Provider 架構、Owner サブスク）

### 変更点
- VERSION / CHANGELOG / requirements-checklist / architecture を追加
- WPML 優先の多言語方針を明記

### 受け入れ条件
- [ ] 実装ブランチで参照できること
- [ ] 以降の PR がこの spec バージョンに準拠すること
