### PR TITLE
docs(arch): lock v0.4.1 + Embed/WP Connector + Domain Mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,64 @@
-﻿# WordPress local dev
-.wp-env/
-dist/
-_testdata/
+# WordPress Core
+/wp-admin/
+/wp-content/
+/wp-includes/
+wp-config.php
+wp-config-sample.php
+wp-*.php
+xmlrpc.php
+.htaccess
 
-# IDE
+# Debug files
+debug.log
+debug*.log
+debug*.php
+wp-debug.log
+error_log
+
+# IDEs and editors
 .idea/
 .vscode/
+*.swp
+*.swo
+*~
 
-# OS
+# OS generated files
 .DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
 Thumbs.db
 
-# Node
+# Temporary files
+*.tmp
+*.temp
+*~
+
+# Dependencies
 node_modules/
+vendor/
+composer.lock
+
+# Build artifacts
+/build/
+/dist/
+*.min.js
+*.min.css
+
+# Logs
+*.log
+logs/
+
+# Environment files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Plugin specific
+/uploads/
+/cache/
+/backups/

--- a/docs/spec/CHANGELOG.md
+++ b/docs/spec/CHANGELOG.md
@@ -1,0 +1,4 @@
+## v0.4.1 (rebuild baseline)
+- Reset repo and branch to a clean state
+- Guarded loader (subplugin-first for ICS, class_exists/file_exists)
+- Phased rebuild plan (M0..M4) with acceptance checks & rollback tags

--- a/docs/spec/VERSION
+++ b/docs/spec/VERSION
@@ -1,0 +1,3 @@
+spec: 0.4.1
+date: 2025-09-21
+notes: Clean rebuild baseline from v0.4.0 spec. Focus on stable loader, Property/Booking CPT, ACF fields, ICS UI, Manual Booking, AvailabilityService (bookings+ical+rules), REST+Shortcode, cache+invalidate.

--- a/docs/spec/VERSION
+++ b/docs/spec/VERSION
@@ -1,3 +1,3 @@
 spec: 0.4.1
 date: 2025-09-21
-notes: Clean rebuild baseline from v0.4.0 spec. Focus on stable loader, Property/Booking CPT, ACF fields, ICS UI, Manual Booking, AvailabilityService (bookings+ical+rules), REST+Shortcode, cache+invalidate.
+notes: Clean rebuild baseline. Focus on Embed+WP Connector+Domain Mapping; stable loader; Property/Booking CPT; ACF; ICS UI; Manual Booking; AvailabilityService; REST+Shortcode; cache+invalidate.

--- a/docs/spec/architecture.md
+++ b/docs/spec/architecture.md
@@ -1,0 +1,57 @@
+# Architecture Addendum (v0.4.1): Embed + WP Connector + Domain Mapping
+
+## Objectives
+- Owners can keep any official website (WordPress or other CMS) while **all inventory/price/booking is centralized** in Minpaku Suite (the portal).
+- Provide two integration modes:
+  - **B: WP Connector** — A WordPress plugin that renders availability/quote UI via portal APIs. Checkout is handled by the portal (hosted).
+  - **C: White-label Sites** — Mini-sites hosted by the portal with optional **custom domain mapping** (CNAME). Zero setup for owners.
+
+## High-level Components
+1) **Portal Core (Minpaku Suite)**
+   - Multi-tenant (Owner, Property)
+   - Booking, Pricing/Rules, iCal sync, Payments, Webhooks
+   - Public APIs: /v1/availability, /v1/quote, /v1/bookings
+   - Embed assets: mbed.js, widget.html
+2) **WP Connector (External WP)**
+   - Shortcodes/Blocks: [minpaku_availability property_id="..."]
+   - Admin settings: API Key + HMAC Secret (stored in options, non-export)
+   - Renders calendar & quote using Portal APIs; checkout opens hosted portal flow (modal or redirect)
+3) **White-label Site**
+   - Route: https://{tenant-sub}.portal.example.com/stay/{property-slug}
+   - Optional **Custom Domain**: CNAME stay.owner.com -> {tenant-sub}.portal.example.com
+   - Theming via sections (Hero/Gallery/Calendar/Quote)
+4) **Security**
+   - HMAC-signed POST (bookings), reCAPTCHA, IP + Owner + Property Rate-limit
+   - CORS: GET allowed w/ cache; POST only from trusted origins (widget host / same-site)
+   - PII & payments strictly on portal; connector never stores payment tokens
+5) **Observability**
+   - Widget events (view, date_select, begin_checkout, purchase) -> dataLayer hooks
+   - Webhooks: ooking.created, payment.captured, ooking.cancelled
+
+## Data Flows
+- **Widget (B/C)** → GET /v1/availability?property_id&from&to (cacheable)
+- Quote: POST /v1/quote ({ checkin, checkout, guests, coupon? })
+- Booking: POST /v1/bookings (HMAC) → Payment → Webhook → Booking confirmed
+- Invalidation: booking change / iCal import / rule update → purge cached availability
+
+## Domain Mapping (White-label)
+- Owner chooses stay.owner.com
+- DNS: CNAME stay.owner.com -> wl.portal.example.com
+- Validation: ACME/HTTP or TXT; validate + issue TLS cert
+- Traffic: CDN (edge) → portal → white-label renderer
+
+## Minimal API Surface (v1)
+- GET /v1/availability → 200 [{date, status: available|partial|blocked|blackout, min_stay?}]
+- POST /v1/quote → 200 { totals, taxes, fees, policy, hold_expires_at }
+- POST /v1/bookings (HMAC) → 201 { booking_id, payment_client_secret? }
+- Headers: X-Minpaku-Cache: HIT|MISS, X-RateLimit-*
+
+## Versioning / Contracts
+- Embed widget version in URL: /embed/v1/embed.js
+- Connector plugin declares X-Minpaku-Connector: 1.x
+- Breaking changes via /v2/* with dual-serve window
+
+## Acceptance (Architecture)
+- External WP can render calendar/quote and complete booking via portal.
+- White-label site renders same property with consistent availability/pricing.
+- Booking consistency: one source of truth (portal DB), webhooks emitted.

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -1,1 +1,42 @@
-<?php // bootstrap placeholder ?>
+<?php
+
+namespace MinpakuSuite;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Bootstrap
+{
+    public static function init()
+    {
+        self::init_hooks();
+        self::init_rest_api();
+        self::init_acf();
+    }
+
+    public static function activate()
+    {
+        // Activation logic will be implemented in future milestones
+    }
+
+    public static function deactivate()
+    {
+        // Deactivation logic will be implemented in future milestones
+    }
+
+    private static function init_hooks()
+    {
+        // WordPress hooks initialization will be implemented in future milestones
+    }
+
+    private static function init_rest_api()
+    {
+        // REST API initialization will be implemented in future milestones
+    }
+
+    private static function init_acf()
+    {
+        // ACF (Advanced Custom Fields) initialization will be implemented in future milestones
+    }
+}

--- a/languages/minpaku-suite.pot
+++ b/languages/minpaku-suite.pot
@@ -1,0 +1,33 @@
+# Minpaku Suite
+# Copyright (C) 2024 Yato1214
+# This file is distributed under the same license as the Minpaku Suite package.
+msgid ""
+msgstr ""
+"Project-Id-Version: Minpaku Suite 0.4.1\n"
+"Report-Msgid-Bugs-To: https://github.com/yato1214/minpaku-suite\n"
+"POT-Creation-Date: 2024-09-21 14:00+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: WP-CLI 2.4.0\n"
+"X-Domain: minpaku-suite\n"
+
+#. Plugin Name of the plugin/theme
+msgid "Minpaku Suite"
+msgstr ""
+
+#. Plugin URI of the plugin/theme
+msgid "https://github.com/yato1214/minpaku-suite"
+msgstr ""
+
+#. Description of the plugin/theme
+msgid "Comprehensive suite for managing minpaku (vacation rental) properties with channel sync capabilities."
+msgstr ""
+
+#. Author of the plugin/theme
+msgid "Yato1214"
+msgstr ""

--- a/minpaku-suite.php
+++ b/minpaku-suite.php
@@ -1,63 +1,77 @@
 <?php
-/*
-Plugin Name: Minpaku Suite
-Description: ICS 同期＆ユーティリティ
-Version: 0.1.0
-Requires at least: 6.0
-Requires PHP: 8.1
-Text Domain: minpaku-suite
-*/
-if (!defined('ABSPATH')) exit;
-
-// Plugin activation hook
-register_activation_hook(__FILE__, 'mcs_activate_plugin');
-
-// Plugin deactivation hook
-register_deactivation_hook(__FILE__, 'mcs_deactivate_plugin');
-
 /**
- * Plugin activation callback
+ * Plugin Name: Minpaku Suite
+ * Plugin URI: https://github.com/yato1214/minpaku-suite
+ * Description: Comprehensive suite for managing minpaku (vacation rental) properties with channel sync capabilities.
+ * Version: 0.4.1
+ * Author: Yato1214
+ * Text Domain: minpaku-suite
+ * Domain Path: /languages
+ * Requires at least: 5.0
+ * Requires PHP: 7.4
+ * Network: false
  */
-function mcs_activate_plugin() {
-    // Load ICS class to register rewrite rules
-    require_once __DIR__ . '/includes/class-mcs-ics.php';
-    MCS_Ics::flush_rewrite_rules();
+
+if (!defined('ABSPATH')) {
+    exit;
 }
 
-/**
- * Plugin deactivation callback
- */
-function mcs_deactivate_plugin() {
-    // Flush rewrite rules to clean up
-    flush_rewrite_rules();
+define('MINPAKU_SUITE_VERSION', '0.4.1');
+define('MINPAKU_SUITE_PLUGIN_FILE', __FILE__);
+define('MINPAKU_SUITE_PLUGIN_DIR', plugin_dir_path(__FILE__));
+define('MINPAKU_SUITE_PLUGIN_URL', plugin_dir_url(__FILE__));
+
+function minpaku_suite_load_textdomain() {
+    load_plugin_textdomain(
+        'minpaku-suite',
+        false,
+        dirname(plugin_basename(__FILE__)) . '/languages'
+    );
 }
+add_action('plugins_loaded', 'minpaku_suite_load_textdomain');
 
-// Load core functionality
-require_once __DIR__ . '/includes/class-mcs-ics.php';
-require_once __DIR__ . '/includes/class-mcs-sync.php';
-require_once __DIR__ . '/includes/class-mcs-cli.php';
-require_once __DIR__ . '/includes/cpt-property.php';
+function minpaku_suite_load_ics() {
+    $mcs_ics_path = WP_PLUGIN_DIR . '/minpaku-channel-sync/includes/class-mcs-ics.php';
 
-// Initialize ICS handler
-add_action('init', ['MCS_Ics', 'init']);
-
-// Initialize WP-CLI commands
-add_action('init', ['MCS_CLI', 'init']);
-
-// Load admin UI if in admin area
-if (is_admin()) {
-    require_once __DIR__ . '/admin/class-mcs-admin.php';
-    add_action('plugins_loaded', ['MCS_Admin', 'init']);
-}
-
-// Add settings link to plugin actions
-add_filter('plugin_action_links_' . plugin_basename(__FILE__), function($links) {
-    if (current_user_can('manage_options')) {
-        $settings_link = '<a href="' . admin_url('admin.php?page=mcs-settings') . '">' . __('Settings', 'minpaku-suite') . '</a>';
-        array_unshift($links, $settings_link);
+    if (is_plugin_active('minpaku-channel-sync/minpaku-channel-sync.php')) {
+        if (file_exists($mcs_ics_path)) {
+            require_once $mcs_ics_path;
+        }
     }
-    return $links;
-});
 
-// 必要ならここから読み込み
-// require_once __DIR__ . '/includes/bootstrap.php';
+    $builtin_ics_path = MINPAKU_SUITE_PLUGIN_DIR . 'includes/class-ics.php';
+    if (file_exists($builtin_ics_path) && !class_exists('MCS_Ics')) {
+        require_once $builtin_ics_path;
+    }
+}
+
+function minpaku_suite_init() {
+    minpaku_suite_load_ics();
+
+    if (file_exists(MINPAKU_SUITE_PLUGIN_DIR . 'includes/Bootstrap.php')) {
+        require_once MINPAKU_SUITE_PLUGIN_DIR . 'includes/Bootstrap.php';
+
+        if (class_exists('MinpakuSuite\Bootstrap')) {
+            MinpakuSuite\Bootstrap::init();
+        }
+    }
+}
+add_action('init', 'minpaku_suite_init');
+
+function minpaku_suite_activate() {
+    flush_rewrite_rules();
+
+    if (class_exists('MinpakuSuite\Bootstrap')) {
+        MinpakuSuite\Bootstrap::activate();
+    }
+}
+register_activation_hook(__FILE__, 'minpaku_suite_activate');
+
+function minpaku_suite_deactivate() {
+    flush_rewrite_rules();
+
+    if (class_exists('MinpakuSuite\Bootstrap')) {
+        MinpakuSuite\Bootstrap::deactivate();
+    }
+}
+register_deactivation_hook(__FILE__, 'minpaku_suite_deactivate');


### PR DESCRIPTION
This PR locks v0.4.1 baseline and adds the architecture addendum for:
- Embed Widget
- WordPress Connector (external sites)
- White-label sites with custom domain mapping (CNAME)

Single-branch workflow: rebuild/v0.4.1 → base: main. Tag: v0.4.1-m0-empty